### PR TITLE
Put TensorPtr in CMakeLists.txt

### DIFF
--- a/thpp/CMakeLists.txt
+++ b/thpp/CMakeLists.txt
@@ -55,6 +55,8 @@ SET(h
   StorageBase-inl.h
   TensorBase.h
   TensorBase-inl.h
+  TensorPtr.h
+  TensorPtr-inl.h
 )
 
 SET(h_detail


### PR DESCRIPTION
Fixes error when building fblualib.

`
/usr/local/include/thpp/TensorBase.h:14:28: fatal error: thpp/TensorPtr.h: No such file or directory
 #include <thpp/TensorPtr.h>
`
